### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/lib/jinja2/_stringdefs.py
+++ b/lib/jinja2/_stringdefs.py
@@ -121,12 +121,12 @@ if __name__ == '__main__':
             # Jython can't handle isolated surrogates
             f.write("""\
 try:
-    Cs = eval(r"%r")
+    Cs = eval(r"{0!r}")
 except UnicodeDecodeError:
-    Cs = '' # Jython can't handle isolated surrogates\n\n""" % val)
+    Cs = '' # Jython can't handle isolated surrogates\n\n""".format(val))
         else:
-            f.write('%s = %r\n\n' % (cat, val))
-    f.write('cats = %r\n\n' % sorted(categories.keys()))
+            f.write('{0!s} = {1!r}\n\n'.format(cat, val))
+    f.write('cats = {0!r}\n\n'.format(sorted(categories.keys())))
 
     f.write(footer)
     f.close()

--- a/lib/jinja2/bccache.py
+++ b/lib/jinja2/bccache.py
@@ -222,7 +222,7 @@ class FileSystemBytecodeCache(BytecodeCache):
             raise RuntimeError('Cannot determine safe temp directory.  You '
                                'need to explicitly provide one.')
 
-        dirname = '_jinja2-cache-%d' % os.getuid()
+        dirname = '_jinja2-cache-{0:d}'.format(os.getuid())
         actual_dir = os.path.join(tmpdir, dirname)
         try:
             os.mkdir(actual_dir, stat.S_IRWXU) # 0o700

--- a/lib/jinja2/debug.py
+++ b/lib/jinja2/debug.py
@@ -103,7 +103,7 @@ class ProcessedTraceback(object):
     def render_as_html(self, full=False):
         """Return a unicode string with the traceback as rendered HTML."""
         from jinja2.debugrenderer import render_traceback
-        return u'%s\n\n<!--\n%s\n-->' % (
+        return u'{0!s}\n\n<!--\n{1!s}\n-->'.format(
             render_traceback(self, full=full),
             self.render_as_text().decode('utf-8', 'replace')
         )
@@ -242,7 +242,7 @@ def fake_exc_info(exc_info, filename, lineno):
             if function == 'root':
                 location = 'top-level template code'
             elif function.startswith('block_'):
-                location = 'block "%s"' % function[6:]
+                location = 'block "{0!s}"'.format(function[6:])
             else:
                 location = 'template'
         code = code_type(0, code.co_nlocals, code.co_stacksize,

--- a/lib/jinja2/environment.py
+++ b/lib/jinja2/environment.py
@@ -410,7 +410,7 @@ class Environment(object):
         """
         func = self.filters.get(name)
         if func is None:
-            raise TemplateRuntimeError('no filter named %r' % name)
+            raise TemplateRuntimeError('no filter named {0!r}'.format(name))
         args = [value] + list(args or ())
         if getattr(func, 'contextfilter', False):
             if context is None:
@@ -435,7 +435,7 @@ class Environment(object):
         """
         func = self.tests.get(name)
         if func is None:
-            raise TemplateRuntimeError('no test named %r' % name)
+            raise TemplateRuntimeError('no test named {0!r}'.format(name))
         return func(value, *(args or ()), **(kwargs or {}))
 
     @internalcode
@@ -658,11 +658,11 @@ class Environment(object):
             from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED, ZIP_STORED
             zip_file = ZipFile(target, 'w', dict(deflated=ZIP_DEFLATED,
                                                  stored=ZIP_STORED)[zip])
-            log_function('Compiling into Zip archive "%s"' % target)
+            log_function('Compiling into Zip archive "{0!s}"'.format(target))
         else:
             if not os.path.isdir(target):
                 os.makedirs(target)
-            log_function('Compiling into folder "%s"' % target)
+            log_function('Compiling into folder "{0!s}"'.format(target))
 
         try:
             for name in self.list_templates(extensions, filter_func):
@@ -672,7 +672,7 @@ class Environment(object):
                 except TemplateSyntaxError as e:
                     if not ignore_errors:
                         raise
-                    log_function('Could not compile "%s": %s' % (name, e))
+                    log_function('Could not compile "{0!s}": {1!s}'.format(name, e))
                     continue
 
                 filename = ModuleLoader.get_module_filename(name)
@@ -681,11 +681,10 @@ class Environment(object):
                     c = self._compile(code, encode_filename(filename))
                     write_file(filename + 'c', py_header +
                                marshal.dumps(c), 'wb')
-                    log_function('Byte-compiled "%s" as %s' %
-                                 (name, filename + 'c'))
+                    log_function('Byte-compiled "{0!s}" as {1!s}'.format(name, filename + 'c'))
                 else:
                     write_file(filename, code, 'w')
-                    log_function('Compiled "%s" as %s' % (name, filename))
+                    log_function('Compiled "{0!s}" as {1!s}'.format(name, filename))
         finally:
             if zip:
                 zip_file.close()
@@ -1053,10 +1052,10 @@ class Template(object):
 
     def __repr__(self):
         if self.name is None:
-            name = 'memory:%x' % id(self)
+            name = 'memory:{0:x}'.format(id(self))
         else:
             name = repr(self.name)
-        return '<%s %s>' % (self.__class__.__name__, name)
+        return '<{0!s} {1!s}>'.format(self.__class__.__name__, name)
 
 
 @implements_to_string
@@ -1079,10 +1078,10 @@ class TemplateModule(object):
 
     def __repr__(self):
         if self.__name__ is None:
-            name = 'memory:%x' % id(self)
+            name = 'memory:{0:x}'.format(id(self))
         else:
             name = repr(self.__name__)
-        return '<%s %s>' % (self.__class__.__name__, name)
+        return '<{0!s} {1!s}>'.format(self.__class__.__name__, name)
 
 
 class TemplateExpression(object):

--- a/lib/jinja2/exceptions.py
+++ b/lib/jinja2/exceptions.py
@@ -98,10 +98,10 @@ class TemplateSyntaxError(TemplateError):
             return self.message
 
         # otherwise attach some stuff
-        location = 'line %d' % self.lineno
+        location = 'line {0:d}'.format(self.lineno)
         name = self.filename or self.name
         if name:
-            location = 'File "%s", %s' % (name, location)
+            location = 'File "{0!s}", {1!s}'.format(name, location)
         lines = [self.message, '  ' + location]
 
         # if the source is set, add the line to the output

--- a/lib/jinja2/ext.py
+++ b/lib/jinja2/ext.py
@@ -233,8 +233,8 @@ class InternationalizationExtension(Extension):
 
             name = parser.stream.expect('name')
             if name.value in variables:
-                parser.fail('translatable variable %r defined twice.' %
-                            name.value, name.lineno,
+                parser.fail('translatable variable {0!r} defined twice.'.format(
+                            name.value), name.lineno,
                             exc=TemplateAssertionError)
 
             # expressions
@@ -275,8 +275,8 @@ class InternationalizationExtension(Extension):
             if parser.stream.current.type != 'block_end':
                 name = parser.stream.expect('name')
                 if name.value not in variables:
-                    parser.fail('unknown variable %r for pluralization' %
-                                name.value, name.lineno,
+                    parser.fail('unknown variable {0!r} for pluralization'.format(
+                                name.value), name.lineno,
                                 exc=TemplateAssertionError)
                 plural_expr = variables[name.value]
                 num_called_num = name.value == 'num'
@@ -318,7 +318,7 @@ class InternationalizationExtension(Extension):
                 next(parser.stream)
                 name = parser.stream.expect('name').value
                 referenced.append(name)
-                buf.append('%%(%s)s' % name)
+                buf.append('%({0!s})s'.format(name))
                 parser.stream.expect('variable_end')
             elif parser.stream.current.type == 'block_begin':
                 next(parser.stream)

--- a/lib/jinja2/filters.py
+++ b/lib/jinja2/filters.py
@@ -160,7 +160,7 @@ def do_xmlattr(_eval_ctx, d, autospace=True):
     if the filter returned something unless the second parameter is false.
     """
     rv = u' '.join(
-        u'%s="%s"' % (escape(key), escape(value))
+        u'{0!s}="{1!s}"'.format(escape(key), escape(value))
         for key, value in iteritems(d)
         if value is not None and not isinstance(value, Undefined)
     )
@@ -390,13 +390,13 @@ def do_filesizeformat(value, binary=False):
     if bytes == 1:
         return '1 Byte'
     elif bytes < base:
-        return '%d Bytes' % bytes
+        return '{0:d} Bytes'.format(bytes)
     else:
         for i, prefix in enumerate(prefixes):
             unit = base ** (i + 2)
             if bytes < unit:
-                return '%.1f %s' % ((base * bytes / unit), prefix)
-        return '%.1f %s' % ((base * bytes / unit), prefix)
+                return '{0:.1f} {1!s}'.format((base * bytes / unit), prefix)
+        return '{0:.1f} {1!s}'.format((base * bytes / unit), prefix)
 
 
 def do_pprint(value, verbose=False):
@@ -823,8 +823,8 @@ def do_map(*args, **kwargs):
     if len(args) == 2 and 'attribute' in kwargs:
         attribute = kwargs.pop('attribute')
         if kwargs:
-            raise FilterArgumentError('Unexpected keyword argument %r' %
-                next(iter(kwargs)))
+            raise FilterArgumentError('Unexpected keyword argument {0!r}'.format(
+                next(iter(kwargs))))
         func = make_attrgetter(context.environment, attribute)
     else:
         try:

--- a/lib/jinja2/loaders.py
+++ b/lib/jinja2/loaders.py
@@ -86,8 +86,8 @@ class BaseLoader(object):
         the template will be reloaded.
         """
         if not self.has_source_access:
-            raise RuntimeError('%s cannot provide access to the source' %
-                               self.__class__.__name__)
+            raise RuntimeError('{0!s} cannot provide access to the source'.format(
+                               self.__class__.__name__))
         raise TemplateNotFound(template)
 
     def list_templates(self):
@@ -424,7 +424,7 @@ class ModuleLoader(BaseLoader):
     has_source_access = False
 
     def __init__(self, path):
-        package_name = '_jinja2_module_templates_%x' % id(self)
+        package_name = '_jinja2_module_templates_{0:x}'.format(id(self))
 
         # create a fake module that looks for the templates in the
         # path given.
@@ -455,7 +455,7 @@ class ModuleLoader(BaseLoader):
     @internalcode
     def load(self, environment, name, globals=None):
         key = self.get_template_key(name)
-        module = '%s.%s' % (self.package_name, key)
+        module = '{0!s}.{1!s}'.format(self.package_name, key)
         mod = getattr(self.module, module, None)
         if mod is None:
             try:

--- a/lib/jinja2/nodes.py
+++ b/lib/jinja2/nodes.py
@@ -130,9 +130,9 @@ class Node(with_metaclass(NodeType, object)):
         if fields:
             if len(fields) != len(self.fields):
                 if not self.fields:
-                    raise TypeError('%r takes 0 arguments' %
-                                    self.__class__.__name__)
-                raise TypeError('%r takes 0 or %d argument%s' % (
+                    raise TypeError('{0!r} takes 0 arguments'.format(
+                                    self.__class__.__name__))
+                raise TypeError('{0!r} takes 0 or {1:d} argument{2!s}'.format(
                     self.__class__.__name__,
                     len(self.fields),
                     len(self.fields) != 1 and 's' or ''
@@ -142,8 +142,8 @@ class Node(with_metaclass(NodeType, object)):
         for attr in self.attributes:
             setattr(self, attr, attributes.pop(attr, None))
         if attributes:
-            raise TypeError('unknown attribute %r' %
-                            next(iter(attributes)))
+            raise TypeError('unknown attribute {0!r}'.format(
+                            next(iter(attributes))))
 
     def iter_fields(self, exclude=None, only=None):
         """This method iterates over all fields that are defined and yields
@@ -236,9 +236,9 @@ class Node(with_metaclass(NodeType, object)):
     __hash__ = object.__hash__
 
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{0!s}({1!s})'.format(
             self.__class__.__name__,
-            ', '.join('%s=%r' % (arg, getattr(self, arg, None)) for
+            ', '.join('{0!s}={1!r}'.format(arg, getattr(self, arg, None)) for
                       arg in self.fields)
         )
 
@@ -719,7 +719,7 @@ class Operand(Helper):
 
 if __debug__:
     Operand.__doc__ += '\nThe following operators are available: ' + \
-        ', '.join(sorted('``%s``' % x for x in set(_binop_to_func) |
+        ', '.join(sorted('``{0!s}``'.format(x) for x in set(_binop_to_func) |
                   set(_uaop_to_func) | set(_cmpop_to_func)))
 
 

--- a/lib/jinja2/parser.py
+++ b/lib/jinja2/parser.py
@@ -56,7 +56,7 @@ class Parser(object):
             expected.extend(imap(describe_token_expr, exprs))
         if end_token_stack:
             currently_looking = ' or '.join(
-                "'%s'" % describe_token_expr(expr)
+                "'{0!s}'".format(describe_token_expr(expr))
                 for expr in end_token_stack[-1])
         else:
             currently_looking = None
@@ -64,7 +64,7 @@ class Parser(object):
         if name is None:
             message = ['Unexpected end of template.']
         else:
-            message = ['Encountered unknown tag \'%s\'.' % name]
+            message = ['Encountered unknown tag \'{0!s}\'.'.format(name)]
 
         if currently_looking:
             if name is not None and name in expected:
@@ -107,7 +107,7 @@ class Parser(object):
         """Return a new free identifier as :class:`~jinja2.nodes.InternalName`."""
         self._last_identifier += 1
         rv = object.__new__(nodes.InternalName)
-        nodes.Node.__init__(rv, 'fi%d' % self._last_identifier, lineno=lineno)
+        nodes.Node.__init__(rv, 'fi{0:d}'.format(self._last_identifier), lineno=lineno)
         return rv
 
     def parse_statement(self):
@@ -373,8 +373,8 @@ class Parser(object):
                 target = self.parse_primary()
             target.set_ctx('store')
         if not target.can_assign():
-            self.fail('can\'t assign to %r' % target.__class__.
-                      __name__.lower(), target.lineno)
+            self.fail('can\'t assign to {0!r}'.format(target.__class__.
+                      __name__.lower()), target.lineno)
         return target
 
     def parse_expression(self, with_condexpr=True):
@@ -572,7 +572,7 @@ class Parser(object):
         elif token.type == 'lbrace':
             node = self.parse_dict()
         else:
-            self.fail("unexpected '%s'" % describe_token(token), token.lineno)
+            self.fail("unexpected '{0!s}'".format(describe_token(token)), token.lineno)
         return node
 
     def parse_tuple(self, simplified=False, with_condexpr=True,
@@ -625,8 +625,8 @@ class Parser(object):
             # nothing) in the spot of an expression would be an empty
             # tuple.
             if not explicit_parentheses:
-                self.fail('Expected an expression, got \'%s\'' %
-                          describe_token(self.stream.current))
+                self.fail('Expected an expression, got \'{0!s}\''.format(
+                          describe_token(self.stream.current)))
 
         return nodes.Tuple(args, 'load', lineno=lineno)
 

--- a/lib/jinja2/runtime.py
+++ b/lib/jinja2/runtime.py
@@ -81,7 +81,7 @@ class TemplateReference(object):
         return BlockReference(name, self.__context, blocks, 0)
 
     def __repr__(self):
-        return '<%s %r>' % (
+        return '<{0!s} {1!r}>'.format(
             self.__class__.__name__,
             self.__context.name
         )
@@ -235,7 +235,7 @@ class Context(object):
         return item
 
     def __repr__(self):
-        return '<%s %s of %r>' % (
+        return '<{0!s} {1!s} of {2!r}>'.format(
             self.__class__.__name__,
             repr(self.get_all()),
             self.name
@@ -264,8 +264,8 @@ class BlockReference(object):
         """Super the block."""
         if self._depth + 1 >= len(self._stack):
             return self._context.environment. \
-                undefined('there is no parent block called %r.' %
-                          self.name, name='super')
+                undefined('there is no parent block called {0!r}.'.format(
+                          self.name), name='super')
         return BlockReference(self.name, self._context, self._stack,
                               self._depth + 1)
 
@@ -346,7 +346,7 @@ class LoopContext(object):
         return self._length
 
     def __repr__(self):
-        return '<%s %r/%r>' % (
+        return '<{0!s} {1!r}/{2!r}>'.format(
             self.__class__.__name__,
             self.index,
             self.length
@@ -407,7 +407,7 @@ class Macro(object):
                         value = self.defaults[idx - self._argument_count + off]
                     except IndexError:
                         value = self._environment.undefined(
-                            'parameter %r was not provided' % name, name=name)
+                            'parameter {0!r} was not provided'.format(name), name=name)
                 arguments.append(value)
 
         # it's important that the order of these arguments does not change
@@ -422,17 +422,15 @@ class Macro(object):
         if self.catch_kwargs:
             arguments.append(kwargs)
         elif kwargs:
-            raise TypeError('macro %r takes no keyword argument %r' %
-                            (self.name, next(iter(kwargs))))
+            raise TypeError('macro {0!r} takes no keyword argument {1!r}'.format(self.name, next(iter(kwargs))))
         if self.catch_varargs:
             arguments.append(args[self._argument_count:])
         elif len(args) > self._argument_count:
-            raise TypeError('macro %r takes not more than %d argument(s)' %
-                            (self.name, len(self.arguments)))
+            raise TypeError('macro {0!r} takes not more than {1:d} argument(s)'.format(self.name, len(self.arguments)))
         return self._func(*arguments)
 
     def __repr__(self):
-        return '<%s %s>' % (
+        return '<{0!s} {1!s}>'.format(
             self.__class__.__name__,
             self.name is None and 'anonymous' or repr(self.name)
         )
@@ -469,14 +467,14 @@ class Undefined(object):
         """
         if self._undefined_hint is None:
             if self._undefined_obj is missing:
-                hint = '%r is undefined' % self._undefined_name
+                hint = '{0!r} is undefined'.format(self._undefined_name)
             elif not isinstance(self._undefined_name, string_types):
-                hint = '%s has no element %r' % (
+                hint = '{0!s} has no element {1!r}'.format(
                     object_type_repr(self._undefined_obj),
                     self._undefined_name
                 )
             else:
-                hint = '%r has no attribute %r' % (
+                hint = '{0!r} has no attribute {1!r}'.format(
                     object_type_repr(self._undefined_obj),
                     self._undefined_name
                 )
@@ -542,12 +540,12 @@ class DebugUndefined(Undefined):
     def __str__(self):
         if self._undefined_hint is None:
             if self._undefined_obj is missing:
-                return u'{{ %s }}' % self._undefined_name
-            return '{{ no such element: %s[%r] }}' % (
+                return u'{{{{ {0!s} }}}}'.format(self._undefined_name)
+            return '{{{{ no such element: {0!s}[{1!r}] }}}}'.format(
                 object_type_repr(self._undefined_obj),
                 self._undefined_name
             )
-        return u'{{ undefined value printed: %s }}' % self._undefined_hint
+        return u'{{{{ undefined value printed: {0!s} }}}}'.format(self._undefined_hint)
 
 
 @implements_to_string

--- a/lib/jinja2/sandbox.py
+++ b/lib/jinja2/sandbox.py
@@ -99,8 +99,8 @@ def safe_range(*args):
     """
     rng = range(*args)
     if len(rng) > MAX_RANGE:
-        raise OverflowError('range too big, maximum size for range is %d' %
-                            MAX_RANGE)
+        raise OverflowError('range too big, maximum size for range is {0:d}'.format(
+                            MAX_RANGE))
     return rng
 
 
@@ -352,7 +352,7 @@ class SandboxedEnvironment(Environment):
         # the double prefixes are to avoid double keyword argument
         # errors when proxying the call.
         if not __self.is_safe_callable(__obj):
-            raise SecurityError('%r is not safely callable' % (__obj,))
+            raise SecurityError('{0!r} is not safely callable'.format(__obj))
         return __context.call(__obj, *args, **kwargs)
 
 

--- a/lib/jinja2/testsuite/__init__.py
+++ b/lib/jinja2/testsuite/__init__.py
@@ -63,8 +63,7 @@ class JinjaTestCase(unittest.TestCase):
         except Exception as e:
             tb = format_exception(*sys.exc_info())
             if re.search(expected_tb.strip(), ''.join(tb)) is None:
-                raise self.fail('Traceback did not match:\n\n%s\nexpected:\n%s'
-                    % (''.join(tb), expected_tb))
+                raise self.fail('Traceback did not match:\n\n{0!s}\nexpected:\n{1!s}'.format(''.join(tb), expected_tb))
         else:
             self.fail('Expected exception')
 
@@ -77,7 +76,7 @@ def find_all_tests(suite):
         try:
             suites.extend(s)
         except TypeError:
-            yield s, '%s.%s.%s' % (
+            yield s, '{0!s}.{1!s}.{2!s}'.format(
                 s.__class__.__module__,
                 s.__class__.__name__,
                 s._testMethodName
@@ -110,7 +109,7 @@ class BetterLoader(unittest.TestLoader):
                 all_tests.append(testcase)
 
         if not all_tests:
-            raise LookupError('could not find test case for "%s"' % name)
+            raise LookupError('could not find test case for "{0!s}"'.format(name))
 
         if len(all_tests) == 1:
             return all_tests[0]
@@ -153,4 +152,4 @@ def main():
     try:
         unittest.main(testLoader=BetterLoader(), defaultTest='suite')
     except Exception as e:
-        print('Error: %s' % e)
+        print('Error: {0!s}'.format(e))

--- a/lib/jinja2/testsuite/ext.py
+++ b/lib/jinja2/testsuite/ext.py
@@ -113,7 +113,7 @@ class TestExtension(Extension):
         ])]).set_lineno(next(parser.stream).lineno)
 
     def _dump(self, sandboxed, ext_attr, imported_object, context):
-        return '%s|%s|%s|%s' % (
+        return '{0!s}|{1!s}|{2!s}|{3!s}'.format(
             sandboxed,
             ext_attr,
             imported_object,

--- a/lib/jinja2/testsuite/inheritance.py
+++ b/lib/jinja2/testsuite/inheritance.py
@@ -141,7 +141,7 @@ class InheritanceTestCase(JinjaTestCase):
         }))
         tmpl = env.get_template('child')
         for m in range(1, 3):
-            assert tmpl.render(master='master%d' % m) == 'MASTER%dCHILD' % m
+            assert tmpl.render(master='master{0:d}'.format(m)) == 'MASTER{0:d}CHILD'.format(m)
 
     def test_multi_inheritance(self):
         env = Environment(loader=DictLoader({

--- a/lib/jinja2/testsuite/lexnparse.py
+++ b/lib/jinja2/testsuite/lexnparse.py
@@ -83,7 +83,7 @@ class LexerTestCase(JinjaTestCase):
 
     def test_string_escapes(self):
         for char in u'\0', u'\u2668', u'\xe4', u'\t', u'\r', u'\n':
-            tmpl = env.from_string('{{ %s }}' % jinja_string_repr(char))
+            tmpl = env.from_string('{{{{ {0!s} }}}}'.format(jinja_string_repr(char)))
             assert tmpl.render() == char
         assert env.from_string('{{ "\N{HOT SPRINGS}" }}').render() == u'\u2668'
 
@@ -97,7 +97,7 @@ class LexerTestCase(JinjaTestCase):
         for test, expect in iteritems(operators):
             if test in '([{}])':
                 continue
-            stream = env.lexer.tokenize('{{ %s }}' % test)
+            stream = env.lexer.tokenize('{{{{ {0!s} }}}}'.format(test))
             next(stream)
             assert stream.current.type == expect
 
@@ -330,9 +330,9 @@ class SyntaxTestCase(JinjaTestCase):
         for should_fail, sig in tests:
             if should_fail:
                 self.assert_raises(TemplateSyntaxError,
-                    env.from_string, '{{ foo(%s) }}' % sig)
+                    env.from_string, '{{{{ foo({0!s}) }}}}'.format(sig))
             else:
-                env.from_string('foo(%s)' % sig)
+                env.from_string('foo({0!s})'.format(sig))
 
     def test_tuple_expr(self):
         for tmpl in [
@@ -358,10 +358,10 @@ class SyntaxTestCase(JinjaTestCase):
 
     def test_constant_casing(self):
         for const in True, False, None:
-            tmpl = env.from_string('{{ %s }}|{{ %s }}|{{ %s }}' % (
+            tmpl = env.from_string('{{{{ {0!s} }}}}|{{{{ {1!s} }}}}|{{{{ {2!s} }}}}'.format(
                 str(const), str(const).lower(), str(const).upper()
             ))
-            assert tmpl.render() == '%s|%s|' % (const, const)
+            assert tmpl.render() == '{0!s}|{1!s}|'.format(const, const)
 
     def test_test_chaining(self):
         self.assert_raises(TemplateSyntaxError, env.from_string,
@@ -494,7 +494,7 @@ hello
 ${item} ## the rest of the stuff
    <% endfor %>''')
         assert tmpl.render(seq=range(5)) == \
-                ''.join('%s\n' % x for x in range(5))
+                ''.join('{0!s}\n'.format(x) for x in range(5))
         
     def test_lstrip_angle_bracket_compact(self):
         env = Environment('<%', '%>', '${', '}', '<%#', '%>', '%', '##',
@@ -505,7 +505,7 @@ ${item} ## the rest of the stuff
 ${item} ## the rest of the stuff
    <%endfor%>''')
         assert tmpl.render(seq=range(5)) == \
-                ''.join('%s\n' % x for x in range(5))
+                ''.join('{0!s}\n'.format(x) for x in range(5))
         
     def test_php_syntax_with_manual(self):
         env = Environment('<?', '?>', '<?=', '?>', '<!--', '-->',
@@ -525,7 +525,7 @@ ${item} ## the rest of the stuff
     <? for item in seq ?>
         <?= item ?>
     <? endfor ?>''')
-        assert tmpl.render(seq=range(5)) == ''.join('        %s\n' % x for x in range(5))
+        assert tmpl.render(seq=range(5)) == ''.join('        {0!s}\n'.format(x) for x in range(5))
 
     def test_php_syntax_compact(self):
         env = Environment('<?', '?>', '<?=', '?>', '<!--', '-->',
@@ -535,7 +535,7 @@ ${item} ## the rest of the stuff
     <?for item in seq?>
         <?=item?>
     <?endfor?>''')
-        assert tmpl.render(seq=range(5)) == ''.join('        %s\n' % x for x in range(5))
+        assert tmpl.render(seq=range(5)) == ''.join('        {0!s}\n'.format(x) for x in range(5))
 
     def test_erb_syntax(self):
         env = Environment('<%', '%>', '<%=', '%>', '<%#', '%>',
@@ -551,7 +551,7 @@ ${item} ## the rest of the stuff
     <%= item %>
     <% endfor %>
 ''')
-        assert tmpl.render(seq=range(5)) == ''.join('    %s\n' % x for x in range(5))
+        assert tmpl.render(seq=range(5)) == ''.join('    {0!s}\n'.format(x) for x in range(5))
 
     def test_erb_syntax_with_manual(self):
         env = Environment('<%', '%>', '<%=', '%>', '<%#', '%>',

--- a/lib/jinja2/testsuite/security.py
+++ b/lib/jinja2/testsuite/security.py
@@ -131,10 +131,10 @@ class SandboxTestCase(JinjaTestCase):
         for expr, ctx, rv in ('1 + 2', {}, '3'), ('a + 2', {'a': 2}, '4'):
             env = SandboxedEnvironment()
             env.binop_table['+'] = disable_op
-            t = env.from_string('{{ %s }}' % expr)
+            t = env.from_string('{{{{ {0!s} }}}}'.format(expr))
             assert t.render(ctx) == rv
             env.intercepted_binops = frozenset(['+'])
-            t = env.from_string('{{ %s }}' % expr)
+            t = env.from_string('{{{{ {0!s} }}}}'.format(expr))
             try:
                 t.render(ctx)
             except TemplateRuntimeError as e:
@@ -148,10 +148,10 @@ class SandboxTestCase(JinjaTestCase):
         for expr, ctx, rv in ('-1', {}, '-1'), ('-a', {'a': 2}, '-2'):
             env = SandboxedEnvironment()
             env.unop_table['-'] = disable_op
-            t = env.from_string('{{ %s }}' % expr)
+            t = env.from_string('{{{{ {0!s} }}}}'.format(expr))
             assert t.render(ctx) == rv
             env.intercepted_unops = frozenset(['-'])
-            t = env.from_string('{{ %s }}' % expr)
+            t = env.from_string('{{{{ {0!s} }}}}'.format(expr))
             try:
                 t.render(ctx)
             except TemplateRuntimeError as e:

--- a/lib/jinja2/utils.py
+++ b/lib/jinja2/utils.py
@@ -17,7 +17,7 @@ from jinja2._compat import text_type, string_types, implements_iterator, \
 
 _word_split_re = re.compile(r'(\s+)')
 _punctuation_re = re.compile(
-    '^(?P<lead>(?:%s)*)(?P<middle>.*?)(?P<trail>(?:%s)*)$' % (
+    '^(?P<lead>(?:{0!s})*)(?P<middle>.*?)(?P<trail>(?:{1!s})*)$'.format(
         '|'.join(map(re.escape, ('(', '<', '&lt;'))),
         '|'.join(map(re.escape, ('.', ',', ')', '>', '\n', '&gt;')))
     )
@@ -167,7 +167,7 @@ def object_type_repr(obj):
         name = obj.__class__.__name__
     else:
         name = obj.__class__.__module__ + '.' + obj.__class__.__name__
-    return '%s object' % name
+    return '{0!s} object'.format(name)
 
 
 def pformat(obj, verbose=False):
@@ -213,15 +213,15 @@ def urlize(text, trim_url_limit=None, nofollow=False):
                     middle.endswith('.net') or
                     middle.endswith('.com')
                 )):
-                middle = '<a href="http://%s"%s>%s</a>' % (middle,
+                middle = '<a href="http://{0!s}"{1!s}>{2!s}</a>'.format(middle,
                     nofollow_attr, trim_url(middle))
             if middle.startswith('http://') or \
                middle.startswith('https://'):
-                middle = '<a href="%s"%s>%s</a>' % (middle,
+                middle = '<a href="{0!s}"{1!s}>{2!s}</a>'.format(middle,
                     nofollow_attr, trim_url(middle))
             if '@' in middle and not middle.startswith('www.') and \
                not ':' in middle and _simple_email_re.match(middle):
-                middle = '<a href="mailto:%s">%s</a>' % (middle, middle)
+                middle = '<a href="mailto:{0!s}">{1!s}</a>'.format(middle, middle)
             if lead + middle + trail != word:
                 words[i] = lead + middle + trail
     return u''.join(words)
@@ -273,7 +273,7 @@ def generate_lorem_ipsum(n=5, html=True, min=20, max=100):
 
     if not html:
         return u'\n\n'.join(result)
-    return Markup(u'\n'.join(u'<p>%s</p>' % escape(x) for x in result))
+    return Markup(u'\n'.join(u'<p>{0!s}</p>'.format(escape(x)) for x in result))
 
 
 def unicode_urlencode(obj, charset='utf-8'):
@@ -372,7 +372,7 @@ class LRUCache(object):
         return len(self._mapping)
 
     def __repr__(self):
-        return '<%s %r>' % (
+        return '<{0!s} {1!r}>'.format(
             self.__class__.__name__,
             self._mapping
         )

--- a/lib/markupsafe/__init__.py
+++ b/lib/markupsafe/__init__.py
@@ -101,7 +101,7 @@ class Markup(text_type):
         return self.__class__(text_type.__mod__(self, arg))
 
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{0!s}({1!s})'.format(
             self.__class__.__name__,
             text_type.__repr__(self)
         )

--- a/lib/markupsafe/tests.py
+++ b/lib/markupsafe/tests.py
@@ -77,7 +77,7 @@ class MarkupTestCase(unittest.TestCase):
              '&lt;bar/&gt;'),
             (Markup('{0[1][bar]}').format([0, {'bar': Markup('<bar/>')}]),
              '<bar/>')):
-            assert actual == expected, "%r should be %r!" % (actual, expected)
+            assert actual == expected, "{0!r} should be {1!r}!".format(actual, expected)
 
     # This is new in 2.7
     if sys.version_info >= (2, 7):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:vim-bootstrap?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:vim-bootstrap?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
